### PR TITLE
♻️ signin -> signInのようにoperationIdを修正

### DIFF
--- a/service/app/routes/auth.py
+++ b/service/app/routes/auth.py
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/user", tags=["auth"], responses=common_schemas.COMMO
 
 @router.post(
     "/sign_in",
-    operation_id="signin",
+    operation_id="sign_in",
     response_model=auth_schemas.SignInResponse,
 )
 async def sign_in(
@@ -38,7 +38,7 @@ async def sign_in(
 
 @router.post(
     "/sign_up",
-    operation_id="signup",
+    operation_id="sign_up",
     response_description="sign up new user",
     response_model=auth_schemas.SignUpResponse,
 )
@@ -57,7 +57,7 @@ async def signup(
 
 @router.post(
     "/sign_out",
-    operation_id="signout", 
+    operation_id="sign_out", 
     response_description="sign out of the user account",
 )
 async def signout(response: Response):

--- a/service/app/routes/word.py
+++ b/service/app/routes/word.py
@@ -76,7 +76,7 @@ async def register_word(
 @router.post(
     "/delete_word", 
     operation_id="delete_word", 
-    response_model=Response,
+    status_code=204,
 )
 async def delete_word(
     payload: word_schemas.DeleteWordRequest, 

--- a/web/src/context/actions.ts
+++ b/web/src/context/actions.ts
@@ -4,10 +4,10 @@ import { ACCESS_TOKEN_KEY } from '@/constant/auth';
 import {
   signedInCheck,
   SignedInCheckResponse,
-  signin,
-  SigninError,
-  SigninResponse,
-  signout,
+  signIn,
+  SignInError,
+  SignInResponse,
+  signOut,
 } from '@/lib/api';
 import { cookies } from 'next/headers';
 
@@ -16,12 +16,12 @@ export const handleLogin = async (
   password: string
 ): Promise<{
   success: boolean;
-  error?: SigninError;
-  data?: SigninResponse;
+  error?: SignInError;
+  data?: SignInResponse;
 }> => {
   const cookieStore = await cookies();
 
-  const res = await signin({
+  const res = await signIn({
     body: {
       username_or_email: userName,
       password: password,
@@ -47,7 +47,7 @@ export const handleLogout = async (): Promise<{
 }> => {
   const cookieStore = await cookies();
 
-  const res = await signout();
+  const res = await signOut();
 
   if (res.error) {
     return { success: false };


### PR DESCRIPTION
- FastAPIが立ち上がらない問題を解消
- signin -> signInのようにoperationIdを修正

FastAPIが立ち上がらなかったのは，response_modelの指定方法に誤りがあったため．

> response_modelの指定方法に誤りがあるためエラーが発生しています。
> 
> response_modelには、レスポンスボディのデータ構造を定義するPydanticモデルを指定する必要があります。しかし、コードではHTTPレスポンスそのものであるfastapi.Responseクラスを指定してしまっています。
> 
> FastAPIはresponse_modelに指定されたPydanticモデルを使い、返り値を検証してJSONに変換しようとします。しかし、fastapi.ResponseオブジェクトはPydanticモデルではないため、この処理に失敗しエラーとなります。
>
> このエンドポイントは204 NO CONTENT（コンテンツなし）を返すことが目的なので、response_modelを使わず、デコレータでstatus_codeを指定するのが最も一般的な方法です。