### PR TITLE
🐛  WordContentの取得をserver action経由に修正

### DIFF
--- a/web/src/components/WordDetailModal/WordDetailModal.tsx
+++ b/web/src/components/WordDetailModal/WordDetailModal.tsx
@@ -2,10 +2,9 @@
 
 import { useEffect, useRef, useState } from "react";
 import { WordInfo } from "@/types/word";
-import { getWordContent } from "@/lib/api";
 import { BiSolidTrash } from "react-icons/bi";
 import { useToast } from "@/context/ToastContext";
-import { handleDeleteWord } from "./actions";
+import { handleDeleteWord, handleGetWordInfo } from "./actions";
 
 type WordDetailModalProps = {
   isOpen: boolean;
@@ -43,20 +42,10 @@ export const WordDetailModal = ({ isOpen, onClose, wordId }: WordDetailModalProp
     const fetchData = async () => {
       setIsLoading(true);
       try {
-        const result = await getWordContent({
-          body: {
-            user_word_id: wordId,
-          },
-        });
+        const result = await handleGetWordInfo(wordId);
 
         if (!ignore && result.data) {
-          setData({
-            id: result.data.user_word_id,
-            spelling: result.data.spelling,
-            meaning: result.data.meaning ?? undefined,
-            exampleSentence: result.data.example_sentence ?? undefined,
-            exampleSentenceTranslation: result.data.example_sentence_translation ?? undefined,
-          });
+          setData(result.data);
         }
       } catch (error) {
         console.error("Failed to fetch", error);

--- a/web/src/components/WordDetailModal/actions.ts
+++ b/web/src/components/WordDetailModal/actions.ts
@@ -1,8 +1,47 @@
 "use server";
 
-import { deleteWord, DeleteWordError, DeleteWordResponse } from "@/lib/api";
+import {
+  deleteWord,
+  DeleteWordError,
+  DeleteWordResponse,
+  getWordContent,
+  GetWordContentError,
+} from "@/lib/api";
 import { cookies } from "next/headers";
 import { revalidatePath } from "next/cache";
+import { WordInfo } from "@/types/word";
+
+/**
+ * 単語の詳細データを取得する
+ */
+export const handleGetWordInfo = async (
+  wordId: string
+): Promise<{
+  success: boolean;
+  error?: GetWordContentError;
+  data?: WordInfo;
+}> => {
+  const res = await getWordContent({
+    body: {
+      user_word_id: wordId,
+    },
+  });
+
+  if (res.error) {
+    return { success: false, error: res.error };
+  }
+
+  return {
+    success: true,
+    data: {
+      id: res.data.user_word_id,
+      spelling: res.data.spelling,
+      meaning: res.data.meaning ?? undefined,
+      exampleSentence: res.data.example_sentence ?? undefined,
+      exampleSentenceTranslation: res.data.example_sentence_translation ?? undefined,
+    },
+  };
+};
 
 /**
  * 単語を削除する


### PR DESCRIPTION
本番環境にて，詳細モーダルがエラーになる問題を解消

原因
- clientコンポーネントから，直接サーバーにアクセスしていたので，CORSに引っかかった

対処法
- 詳細fetchをserver actionにした